### PR TITLE
OCA#53: Fix mandatory newKey argument of the 'custom' GQL model

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oca_client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oca_client",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "axios": "^0.26.1",
         "bootstrap": "5.1.3",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oca_client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "dependencies": {
     "axios": "^0.26.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oca_server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oca_server",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oca_server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "start": "node dist/index.js",
     "dev": "nodemon --exec babel-node src/index.js",

--- a/server/src/custom/graphql/custom.js
+++ b/server/src/custom/graphql/custom.js
@@ -106,7 +106,7 @@ export const CustomMutation = {
         description: 'Unique ID',
       },
       newKey: {
-        type: GraphQLNonNull(GraphQLString),
+        type: GraphQLString,
         description: 'New unique ID',
       },
       params: {

--- a/server/src/layout/graphql/content_type.js
+++ b/server/src/layout/graphql/content_type.js
@@ -67,6 +67,10 @@ export const ContentTypeMutation = {
         description: 'Unique key',
       },
       newKey: {
+        /*
+        This is marked as non-null because this is the only parameter of the object.
+        Change this to optional if the object model has other fields
+        */
         type: GraphQLNonNull(GraphQLString),
         description: 'New key',
       },


### PR DESCRIPTION
Is related to #53 